### PR TITLE
Avoid service binding false error

### DIFF
--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -186,7 +186,7 @@ func (r *ServiceBindingReconciler) createBinding(ctx context.Context, smClient s
 		Parameters:        bindingParameters,
 	}, nil, buildUserInfo(serviceBinding.Spec.UserInfo, log))
 
-	if bindErr != nil {
+	if bindErr != nil && !isAlreadyExistsError(bindErr) {
 		log.Error(err, "failed to create service binding", "serviceInstanceID", serviceInstance.Status.InstanceID)
 		if isTransientError(bindErr, log) {
 			return r.markAsTransientError(ctx, smTypes.CREATE, bindErr, serviceBinding, log)


### PR DESCRIPTION
This PR proposes to check for 409 error on service binding to avoid race conditions in reconcile logic to falsely claim Service Binding failed while it in fact succeeded in a reconcile loop before.

What previously failed with
```
$ k get servicebinding
NAME         INSTANCE              STATUS         READY   AGE
my-binding   my-service-instance   CreateFailed   False   71s
```
```
$ k get servicebinding my-binding -o json | jq '.status.conditions[0].message'
"ServiceBinding create failed: request POST https://service-manager.cfapps.sap.hana.ondemand.com/v1/service_bindings failed: StatusCode: 409 Body: {\"error\":\"Conflict\",\"description\":\"binding with same name exists for instance with id 71215544-0588-4458-af27-7c5d1a621815\"}
```

Now passes
```
$ k get servicebinding
NAME         INSTANCE              STATUS    READY   AGE
my-binding   my-service-instance   Created   True    4s
```

closes: https://github.com/SAP/sap-btp-service-operator/issues/50