### PR TITLE
Fix CrashLoop when status conditions are empty

### DIFF
--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -380,7 +380,13 @@ func bindingAlreadyOwnedByInstance(instance *v1alpha1.ServiceInstance, binding *
 }
 
 func serviceNotUsable(instance *v1alpha1.ServiceInstance) bool {
-	return isDelete(instance.ObjectMeta) || instance.Status.Conditions[0].Reason == getConditionReason(smTypes.CREATE, smTypes.FAILED)
+	if isDelete(instance.ObjectMeta) {
+		return true
+	}
+	if len(instance.Status.Conditions) != 0 {
+		return instance.Status.Conditions[0].Reason == getConditionReason(smTypes.CREATE, smTypes.FAILED)
+	}
+	return false
 }
 
 func (r *ServiceBindingReconciler) getServiceInstanceForBinding(ctx context.Context, binding *v1alpha1.ServiceBinding) (*v1alpha1.ServiceInstance, error) {


### PR DESCRIPTION
When testing migration of `ServiceInstances`, the operator went to `CrashLoopBackOff`
```
$ k get po -nsap-btp-operator
NAME                                                   READY   STATUS             RESTARTS   AGE
sap-btp-operator-controller-manager-595b76f4f8-xj65c   1/2     CrashLoopBackOff   7          28m
```
logs: [crashloop.log](https://github.com/SAP/sap-btp-service-operator/files/6686850/crashloop.log)

Not sure if this is the best place to address the problem but it has resolved the crashes in our use case.
fixes: https://github.com/SAP/sap-btp-service-operator/issues/58