### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This feature is still under development, review, and testing.
 3. Deploy the the SAP BTP service operator in the cluster using the obtained access credentials:<br>
    
    *Note:<br>
-    If you are deploying the SAP BTP service operator in the registered cluster based on the Service Catalog (svcat) and Service Manager agent so that you can migrate svcat-based content to service operator-based content, add ```--set cluster.id=<clusterID>  ``` to your deployment script.*
+    If you are deploying the SAP BTP service operator in the registered cluster based on the Service Catalog (svcat) and Service Manager agent so that you can migrate svcat-based content to service operator-based content, add ```--set cluster.id=<clusterID>  ``` to your deployment script.*<br>*For more information, see the step 2 of the Setup section of [Migration to SAP BTP service operator](https://github.com/SAP/sap-btp-service-operator-migration/blob/main/README.md).*
    
    The example of the deployment that uses the default access credentials type:
     ```bash

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ This feature is still under development, review, and testing.
    
 3. Deploy the the SAP BTP service operator in the cluster using the obtained access credentials:<br>
    
+   *Note:<br>
+    If you are deploying the SAP BTP service operator in the registered cluster based on the Service Catalog (svcat) and Service Manager agent so that you can migrate svcat-based content to service operator-based content, add ```--set cluster.id=<clusterID>  ``` to your deployment script.*
+   
    The example of the deployment that uses the default access credentials type:
     ```bash
     helm upgrade --install sap-btp-operator https://github.com/SAP/sap-btp-service-operator/releases/download/<release>/sap-btp-operator-<release>.tgz \
@@ -107,8 +110,6 @@ This feature is still under development, review, and testing.
         --set manager.secret.tokenurl=<certurl>
     ```
     
-    *Note:<br>
-    If you are deploying the SAP BTP service operator in the registered cluster based on the Service Catalog (svcat) and Service Manager agent so that you can migrate svcat-based content to service operator-based content, add ```--set cluster.id=<clusterID>  ``` to your deployment script.*
 
     The list of available releases: [sapbtp-operator releases](https://github.com/SAP/sap-btp-service-operator/releases)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This feature is still under development, review, and testing.
          "sm_url": "https://service-manager.cfapps.eu10.hana.ondemand.com"
      }
     ```
-    The example of the binding object with X.509 credentials type if specified:
+    The example of the binding object with the specified X.509 credentials type:
     
     ```json
     {
@@ -83,7 +83,9 @@ This feature is still under development, review, and testing.
      }
     ```
    
-3. Deploy the the SAP BTP service operator in the cluster using the obtained access credentials:
+3. Deploy the the SAP BTP service operator in the cluster using the obtained access credentials:<br>
+   
+   The example of the deployment that uses the default access credentials type:
     ```bash
     helm upgrade --install sap-btp-operator https://github.com/SAP/sap-btp-service-operator/releases/download/<release>/sap-btp-operator-<release>.tgz \
         --create-namespace \
@@ -93,7 +95,7 @@ This feature is still under development, review, and testing.
         --set manager.secret.url=<sm_url> \
         --set manager.secret.tokenurl=<url>
     ```
-    with the X.509 certificate credentials type:
+   The example of the deployment that uses the X.509 access credentials type:
     ```bash
     helm upgrade --install sap-btp-operator https://github.com/SAP/sap-btp-service-operator/releases/download/<release>/sap-btp-operator-<release>.tgz \
         --create-namespace \
@@ -104,6 +106,9 @@ This feature is still under development, review, and testing.
         --set manager.secret.url=<sm_url> \
         --set manager.secret.tokenurl=<certurl>
     ```
+    
+    *Note:<br>
+    If you are deploying the SAP BTP service operator in the cluster in which you also want to perform the migration from the SVCAT-based content to SAP BTP service operator-based content, add ```--set cluster.id=<clusterID>  ``` to your deployment script.*
 
     The list of available releases: [sapbtp-operator releases](https://github.com/SAP/sap-btp-service-operator/releases)
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This feature is still under development, review, and testing.
     ```
     
     *Note:<br>
-    If you are deploying the SAP BTP service operator in the cluster in which you also want to perform the migration from the SVCAT-based content to SAP BTP service operator-based content, add ```--set cluster.id=<clusterID>  ``` to your deployment script.*
+    If you are deploying the SAP BTP service operator in the registered cluster based on the Service Catalog (svcat) and Service Manager agent so that you can migrate svcat-based content to service operator-based content, add ```--set cluster.id=<clusterID>  ``` to your deployment script.*
 
     The list of available releases: [sapbtp-operator releases](https://github.com/SAP/sap-btp-service-operator/releases)
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ This feature is still under development, review, and testing.
 2. Obtain the access credentials for the SAP BTP service operator:
 
    a. Using the SAP BTP cockpit or CLI, create an instance of the SAP Service Manager service (technical name: `service-manager`) with the plan:
-    `service-operator-access`<br/>**Note**<br/> If you can't see the needed plan, you need to entitle your subaccount to use SAP Service Manager service.
+    `service-operator-access`<br/><br>*Note*<br/><br>*If you can't see the needed plan, you need to entitle your subaccount to use SAP Service Manager service.*<br>
 
-      For more information about how to entitle a service to a subaccount, see:
-      * [Configure Entitlements and Quotas for Subaccounts](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/5ba357b4fa1e4de4b9fcc4ae771609da.html)  
+      *For more information about how to entitle a service to a subaccount, see:*
+      * *[Configure Entitlements and Quotas for Subaccounts](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/5ba357b4fa1e4de4b9fcc4ae771609da.html)*
       
       
       <br/>For more information about creating service instances, see:     
       * [Creating Service Instances Using the SAP BTP Cockpit](https://help.sap.com/viewer/09cc82baadc542a688176dce601398de/Cloud/en-US/bf71f6a7b7754dbd9dfc2569791ccc96.html)
         
-      * [Creating Service Instances using SMCTL](https://help.sap.com/viewer/09cc82baadc542a688176dce601398de/Cloud/en-US/b327b66b711746b085ec5d2ea16e608e.html)  
+      * [Creating Service Instances using SMCTL](https://help.sap.com/viewer/09cc82baadc542a688176dce601398de/Cloud/en-US/b327b66b711746b085ec5d2ea16e608e.html)<br> 
    
    b. Create a binding to the created service instance.
       


### PR DESCRIPTION
Added a note about the cluster ID param needed for migration and also changed the sentences above the examples for default and X.509 credentials type bindings. 