### PR TITLE
Add tags to the ServiceBinding secret

### DIFF
--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -148,7 +148,11 @@ func (r *ServiceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 			if binding.LastOperation.Type != smTypes.CREATE || binding.LastOperation.State == smTypes.SUCCEEDED {
 				// store secret unless binding is still being created or failed during creation
+				// Look for tags here?
 				if err := r.storeBindingSecret(ctx, serviceBinding, binding, log); err != nil {
+					return r.handleSecretError(ctx, binding.LastOperation.Type, err, serviceBinding, log)
+				}
+				if err := r.storeServiceTags(ctx, serviceBinding, smClient, log); err != nil {
 					return r.handleSecretError(ctx, binding.LastOperation.Type, err, serviceBinding, log)
 				}
 			}
@@ -448,6 +452,13 @@ func (r *ServiceBindingReconciler) storeBindingSecret(ctx context.Context, k8sBi
 		}
 	}
 
+	tags, err := r.getServiceTagsForBinding(ctx, k8sBinding, log)
+	if err != nil {
+		logger.Error(err, "failed to retrieve service tags")
+		return fmt.Errorf("failed to retrieve service tags. Error: %v", err.Error())
+	}
+	credentialsMap["tags"] = tags
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sBinding.Spec.SecretName,
@@ -470,6 +481,86 @@ func (r *ServiceBindingReconciler) storeBindingSecret(ctx context.Context, k8sBi
 	}
 	r.Recorder.Event(k8sBinding, corev1.EventTypeNormal, "SecretCreated", "SecretCreated")
 	return nil
+}
+
+func (r *ServiceBindingReconciler) storeServiceTags(ctx context.Context, binding *v1alpha1.ServiceBinding, client sm.Client, log logr.Logger) error {
+	instance, err := r.getServiceInstanceForBinding(ctx, binding)
+	if err != nil {
+		return err
+	}
+
+	log.Info("retrieving catalog information", "instance", instance.Spec.ServiceOfferingName)
+	query := &sm.Parameters{
+		FieldQuery: []string{fmt.Sprintf("catalog_name eq '%s'", instance.Spec.ServiceOfferingName)},
+	}
+	offerings, err := client.ListOfferings(query)
+	if err != nil {
+		return err
+	}
+
+	tags := []byte{}
+	// There should only be one offering
+	for _, offering := range offerings.ServiceOfferings {
+		log.Info("retrieved tag", "name", string(offering.Tags))
+		tags = offering.Tags
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      binding.Spec.SecretName, // Probably add own configmap name
+			Labels:    map[string]string{"binding": binding.Name},
+			Namespace: binding.Namespace,
+		},
+		Data: map[string]string{
+			"tags": string(tags),
+		},
+	}
+	if err := controllerutil.SetControllerReference(binding, configMap, r.Scheme); err != nil {
+		log.Error(err, "Failed to set configmap owner")
+		return err
+	}
+
+	log.Info("Creating binding configmap")
+	if err := r.Create(ctx, configMap); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		return nil
+	}
+	r.Recorder.Event(binding, corev1.EventTypeNormal, "ConfigMapCreated", "ConfigMapCreated")
+	return nil
+}
+
+func (r *ServiceBindingReconciler) getServiceTagsForBinding(ctx context.Context, binding *v1alpha1.ServiceBinding, log logr.Logger) ([]byte, error) {
+	client, err := r.getSMClient(ctx, binding, log)
+	if err != nil {
+		return nil, err
+	}
+
+	instance, err := r.getServiceInstanceForBinding(ctx, binding)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("retrieving catalog information", "instance", instance.Spec.ServiceOfferingName)
+	query := &sm.Parameters{
+		FieldQuery: []string{fmt.Sprintf("catalog_name eq '%s'", instance.Spec.ServiceOfferingName)},
+	}
+	offerings, err := client.ListOfferings(query)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("retrieved catalog information", "offerings", offerings)
+
+	tags := []byte{}
+	// There should only be one offering
+	for _, offering := range offerings.ServiceOfferings {
+		log.Info("retrieved tag", "name", string(offering.Tags))
+		tags = offering.Tags
+	}
+
+	return tags, nil
 }
 
 func (r *ServiceBindingReconciler) deleteBindingSecret(ctx context.Context, binding *v1alpha1.ServiceBinding, log logr.Logger) error {

--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -461,9 +461,10 @@ func (r *ServiceBindingReconciler) storeBindingSecret(ctx context.Context, k8sBi
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      k8sBinding.Spec.SecretName,
-			Labels:    map[string]string{"binding": k8sBinding.Name},
-			Namespace: k8sBinding.Namespace,
+			Name:        k8sBinding.Spec.SecretName,
+			Labels:      map[string]string{"binding": k8sBinding.Name},
+			Annotations: map[string]string{"servicebindings.services.cloud.sap.com/tags": string(tags)},
+			Namespace:   k8sBinding.Namespace,
 		},
 		Data: credentialsMap,
 	}

--- a/controllers/serviceinstance_controller_test.go
+++ b/controllers/serviceinstance_controller_test.go
@@ -16,7 +16,6 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,7 +85,7 @@ var _ = Describe("ServiceInstance controller", func() {
 	deleteInstance := func(ctx context.Context, instanceToDelete *v1alpha1.ServiceInstance, wait bool) {
 		err := k8sClient.Get(ctx, types.NamespacedName{Name: instanceToDelete.Name, Namespace: instanceToDelete.Namespace}, &v1alpha1.ServiceInstance{})
 		if err != nil {
-			Expect(errors.IsNotFound(err)).To(Equal(true))
+			Expect(apierrors.IsNotFound(err)).To(Equal(true))
 			return
 		}
 
@@ -96,7 +95,7 @@ var _ = Describe("ServiceInstance controller", func() {
 			Eventually(func() bool {
 				a := &v1alpha1.ServiceInstance{}
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: instanceToDelete.Name, Namespace: instanceToDelete.Namespace}, a)
-				return errors.IsNotFound(err)
+				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		}
 	}
@@ -346,7 +345,7 @@ var _ = Describe("ServiceInstance controller", func() {
 					//validate deletion
 					Eventually(func() bool {
 						err := k8sClient.Get(ctx, defaultLookupKey, serviceInstance)
-						return errors.IsNotFound(err)
+						return apierrors.IsNotFound(err)
 					}, timeout, interval).Should(BeTrue())
 				})
 			})
@@ -467,7 +466,7 @@ var _ = Describe("ServiceInstance controller", func() {
 							//validate deletion
 							Eventually(func() bool {
 								err := k8sClient.Get(ctx, defaultLookupKey, updatedInstance)
-								return errors.IsNotFound(err)
+								return apierrors.IsNotFound(err)
 							}, timeout, interval).Should(BeTrue())
 						})
 					})
@@ -649,7 +648,7 @@ var _ = Describe("ServiceInstance controller", func() {
 					deleteInstance(ctx, serviceInstance, false)
 					Eventually(func() bool {
 						err := k8sClient.Get(ctx, defaultLookupKey, serviceInstance)
-						if errors.IsNotFound(err) {
+						if apierrors.IsNotFound(err) {
 							return false
 						}
 						return isFailed(serviceInstance)


### PR DESCRIPTION
With this change an additional key `tags` will be added to the ServiceBinding secret, with the tags being fetched from the corresponding offering.

It's mostly a follow-up change to the one introduced as a fix to #61, in order to provide a better compatibility with the native CF services, which are being moved to K8s (`tags` is a mandatory key for the `VCAP_SERVICES` env variable).