### PR TITLE
Use numerical USER in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 65534:65534
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
 Hi there,
we are using PodSecurityPolicies to harden our cluster. Among other things, these PSPs mandate that pods do not run as root.
However, the default user in the `controller` image is specified by name (`nonroot`) and thus the admission controller cannot determine if it is root or not (see [K8s sources](https://github.com/kubernetes/kubernetes/blob/5648200571889140ad246feb82c8f80a5946f167/pkg/kubelet/kuberuntime/security_context.go#L92)). 
I'd like to change the Dockerfile so that the default user from the distroless image is referenced by uid and not by name (see [here](https://github.com/GoogleContainerTools/distroless/blob/d1a3d9338121dfe009634c70a28cde51fff7e6c9/base/BUILD#L10)). So this change doesn't change the default user, just how it's referenced.

Thank you!