### PR TITLE
make helm chart more gitops friendly

### DIFF
--- a/sapbtp-operator-charts/templates/configmap.yml
+++ b/sapbtp-operator-charts/templates/configmap.yml
@@ -1,10 +1,14 @@
 apiVersion: v1
 data:
+  {{- if .Values.cluster.id }}
+  CLUSTER_ID: {{ .Values.cluster.id }}
+  {{- else }}
   {{- $configmap := lookup "v1" "ConfigMap" .Release.Namespace "sap-btp-operator-config" -}}
   {{- if $configmap }}
   CLUSTER_ID: {{ $configmap.data.CLUSTER_ID }}
-  {{ else }}
-  CLUSTER_ID: {{.Values.cluster.id | default uuidv4}}
+  {{- else }}
+  CLUSTER_ID: {{ uuidv4}}
+  {{- end }}
   {{- end }}
   MANAGEMENT_NAMESPACE: {{.Release.Namespace}}
 kind: ConfigMap

--- a/sapbtp-operator-charts/templates/deployment.yml
+++ b/sapbtp-operator-charts/templates/deployment.yml
@@ -13,7 +13,11 @@ spec:
   template:
     metadata:
       annotations:
-        rollme: {{ randAlphaNum 5 | quote }}
+        {{- $configmap := (include (print $.Template.BasePath "/configmap.yml") .) -}}
+        {{- $secret := (include (print $.Template.BasePath "/secret.yml") .) -}}
+        {{- $secretTls := (include (print $.Template.BasePath "/secret-tls.yml") .) -}}
+        {{- $configSha := (print $configmap $secret $secretTls) | sha256sum -}}
+        checksum/config: {{ $configSha }}
       labels:
         control-plane: controller-manager
     spec:

--- a/sapbtp-operator-charts/templates/secret.yml
+++ b/sapbtp-operator-charts/templates/secret.yml
@@ -1,3 +1,4 @@
+{{ if .Values.manager.secret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,3 +21,4 @@ data:
   {{- if .Values.manager.secret.tokenurlsuffix }}
   tokenurlsuffix: {{ .Values.manager.secret.tokenurlsuffix | b64enc | quote }}
   {{- end }}
+{{ end }}

--- a/sapbtp-operator-charts/values.yaml
+++ b/sapbtp-operator-charts/values.yaml
@@ -11,6 +11,7 @@ manager:
     repository: ghcr.io/sap/sap-btp-service-operator/controller
     tag: master
   secret:
+    enabled: true
     tls:
       crt:
       key:


### PR DESCRIPTION
This change aims to improve the ability to use the helm chart in GitOps scenarios (focus on ArgoCD but should apply with other tools as well)

Changes in detail:

* `configmap.yml` only lookup the value from the cluster if none is defined in the Helm values. This makes the helm values the leading system
* `deployment.yml` only roll the deployment if something changes in the configmap or the secret (otherwise ArgoCD would always report changes and potentially constantly roll the deployment)
* `secret.yml` the secret contains potentially secret data (it does if clientsecret is specified, arguably it does not if clientsecret is omitted?) and it is therefore desirable to manage it differently when using ArgoCD, for example using sealed secrets. Note: for `secret-tls.yml` this scenario already works since it's not templated by default