### PR TITLE
fix broken helm chart

### DIFF
--- a/sapbtp-operator-charts/templates/deployment.yml
+++ b/sapbtp-operator-charts/templates/deployment.yml
@@ -16,7 +16,7 @@ spec:
         {{- $configmap := (include (print $.Template.BasePath "/configmap.yml") .) -}}
         {{- $secret := (include (print $.Template.BasePath "/secret.yml") .) -}}
         {{- $secretTls := (include (print $.Template.BasePath "/secret-tls.yml") .) -}}
-        {{- $configSha := (print $configmap $secret $secretTls) | sha256sum -}}
+        {{- $configSha := (print $configmap $secret $secretTls) | sha256sum }}
         checksum/config: {{ $configSha }}
       labels:
         control-plane: controller-manager


### PR DESCRIPTION
in PR #110 a change was introduced that broke the templated helm chart, this corrects it again.

Sorry for that, I originally failed in correctly bringing the changes to my fork