### PR TITLE
add support for flattening secret data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ sapbtp-operator-charts/templates/sap-operator.yml
 *.swp
 *.swo
 *~
+.vscode
 
 vendor

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ This feature is still under development, review, and testing.
 | secretName       | `string`   |  The name of the secret where the credentials are stored, defaults to the binding `metadata.name` if not specified. |
 | secretKey | `string`  | The key inside the binding secret to store the credentials returned by the broker encoded as json to support complex data structures. |
 | secretRootKey | `string`  | The key inside the secret to store all binding data including credentials returned by the broker and additional info under single key.<br/>Convenient way to store whole binding data in single file when using `volumeMounts`. |
+| flattenSecretTolevel | `integer`  | Flatten complex structures inside the secret binding by concatenating them to a single level seperated by "_". For example `{"a": {"b": "c": "d", "e": "f"}` would create 2 data elements in the created secret: `a_b: {"c": "d"}` and `a_e: f` inside the created secret) |
 | parameters       |  `[]object`  |  Some services support the provisioning of additional configuration parameters during the bind request.<br/>For the list of supported parameters, check the documentation of the particular service offering.|
 | parametersFrom | `[]object` | List of sources to populate parameters. |
 | userInfo | `object`  | Contains information about the user that last modified this service binding. |

--- a/api/v1alpha1/servicebinding_types.go
+++ b/api/v1alpha1/servicebinding_types.go
@@ -57,6 +57,12 @@ type ServiceBindingSpec struct {
 	// +optional
 	SecretRootKey *string `json:"secretRootKey,omitempty"`
 
+	// FlattenSecretToLevel instructs the operator th flatten the returned secret data
+	// directlyt to data in the secret instead of marshalling all in JSON
+	// up to the specified level
+	// +optional
+	FlattenSecretToLevel *int64 `json:"flattenSecretToLevel,omitempty"`
+
 	// Parameters for the binding.
 	//
 	// The Parameters field is NOT secret or secured in any way and should

--- a/config/crd/bases/services.cloud.sap.com_servicebindings.yaml
+++ b/config/crd/bases/services.cloud.sap.com_servicebindings.yaml
@@ -89,6 +89,9 @@ spec:
               secretRootKey:
                 description: SecretRootKey is used as the key inside the secret to store all binding data including credentials returned by the broker and additional info under single key. Convenient way to store whole binding data in single file when using `volumeMounts`.
                 type: string
+              flattenSecretToLevel:
+                description: The data inside the binding is flattened by concatenating nested structured with "_" up to the specified level.
+                type: integer
               serviceInstanceName:
                 description: The k8s name of the service instance to bind, should be in the namespace of the binding
                 minLength: 1

--- a/controllers/controller_util_test.go
+++ b/controllers/controller_util_test.go
@@ -1,0 +1,31 @@
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Controller Util Test Test", func() {
+	BeforeEach(func() {
+	})
+
+	It("should return plain data as is", func() {
+		normalized, _ := normalizeCredentials([]byte(`{"key": "value"}`), 1)
+		Expect(normalized).To(Equal(map[string][]byte{"key": []byte("value")}))
+	})
+
+	It("should create nested JSON structures", func() {
+		normalized, _ := normalizeCredentials([]byte(`{"key": {"nested_key": "nested_value"}}`), 1)
+		Expect(normalized).To(Equal(map[string][]byte{"key": []byte(`{"nested_key":"nested_value"}`)}))
+	})
+
+	It("should flatten nested JSON structures to level 2", func() {
+		normalized, _ := normalizeCredentials([]byte(`{"outerkey": {"nested_key": "nested_value", "deep_nesting": { "deep_nested_key": "deep_nested_value" }}}`), 2)
+		Expect(normalized).To(Equal(map[string][]byte{"outerkey_nested_key": []byte(`nested_value`), "outerkey_deep_nesting": []byte("{\"deep_nested_key\":\"deep_nested_value\"}")}))
+	})
+
+	It("should flatten nested JSON structures to level 3", func() {
+		normalized, _ := normalizeCredentials([]byte(`{"outerkey": {"nested_key": "nested_value", "deep_nesting": { "deep_nested_key": "deep_nested_value" }}}`), 3)
+		Expect(normalized).To(Equal(map[string][]byte{"outerkey_nested_key": []byte(`nested_value`), "outerkey_deep_nesting_deep_nested_key": []byte(`deep_nested_value`)}))
+	})
+})

--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -442,7 +442,11 @@ func (r *ServiceBindingReconciler) storeBindingSecret(ctx context.Context, k8sBi
 		}
 	} else {
 		var err error
-		credentialsMap, err = normalizeCredentials(smBinding.Credentials)
+		flattenLevel := int64(1)
+		if k8sBinding.Spec.FlattenSecretToLevel != nil {
+			flattenLevel = *k8sBinding.Spec.FlattenSecretToLevel
+		}
+		credentialsMap, err = normalizeCredentials(smBinding.Credentials, flattenLevel)
 		if err != nil {
 			logger.Error(err, "Failed to store binding secret")
 			return fmt.Errorf("failed to create secret. Error: %v", err.Error())


### PR DESCRIPTION
when servicebindings contain nested json structures the operator can
now create compound keys by appending "_" between keys to enable a flat
list of data values inside the created secret instead of having secret data
contain json data

implements #114

Note: I'm not very experienced with writing go in general and in particular not with writing Kubernetes operators. Please thoroughly review.

We didn't have the chance yet to sync whether this feature is actually desirable for the project, it would definitely help our use case and it allows more "standard" consumption of service bindings from Kubernetes. If there is need we can have a meeting early in 2022.

Merry Christmas!
