### PR TITLE
Pods contains proper labels

### DIFF
--- a/sapbtp-operator-charts/templates/deployment.yml
+++ b/sapbtp-operator-charts/templates/deployment.yml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
+    app.kubernetes.io/instance: sap-btp-operator
+    app.kubernetes.io/name: sap-btp-operator
   name: sap-btp-operator-controller-manager
   namespace: {{.Release.Namespace}}
 spec:
@@ -20,6 +22,8 @@ spec:
         checksum/config: {{ $configSha }}
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/instance: sap-btp-operator
+        app.kubernetes.io/name: sap-btp-operator
     spec:
       containers:
         - args:

--- a/sapbtp-operator-charts/templates/service.yml
+++ b/sapbtp-operator-charts/templates/service.yml
@@ -9,12 +9,16 @@ spec:
       targetPort: 9443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/instance: sap-btp-operator
+    app.kubernetes.io/name: sap-btp-operator
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     control-plane: controller-manager
+    app.kubernetes.io/instance: sap-btp-operator
+    app.kubernetes.io/name: sap-btp-operator
   name: sap-btp-operator-controller-manager-metrics-service
   namespace: {{.Release.Namespace}}
 spec:


### PR DESCRIPTION

## Motivation

* I've deployed BTP operator and the service with only one label selectors pointed to other applications so webhook was not requested when I was applying BTP operator resources

## Approach

Pods contains labels which identifies only btp operator Pods

This PR fixes the issue: https://github.com/SAP/sap-btp-service-operator/issues/152