### PR TITLE
Add digest option to btp-operator chart

### DIFF
--- a/sapbtp-operator-charts/templates/deployment.yml
+++ b/sapbtp-operator-charts/templates/deployment.yml
@@ -31,11 +31,11 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          #image: quay.io/brancz/kube-rbac-proxy:v0.11.0
-          {{- if .Values.manager.rbac.image.sha }}
-          image: "{{.Values.manager.rbac.image.repository}}@sha256:{{.Values.manager.rbac.image.sha}}"
+          
+          {{- if .Values.manager.rbacProxy.image.sha }}
+          image: "{{.Values.manager.rbacProxy.image.repository}}@sha256:{{.Values.manager.rbacProxy.image.sha}}"
           {{- else }}
-          image: "{{.Values.manager.rbac.repository}}:{{.Values.manager.rbac.image.tag}}"
+          image: "{{.Values.manager.rbacProxy.repository}}:{{.Values.manager.rbacProxy.image.tag}}"
           {{- end }}
  
           {{- if .Values.manager.securityContext }}

--- a/sapbtp-operator-charts/templates/deployment.yml
+++ b/sapbtp-operator-charts/templates/deployment.yml
@@ -61,7 +61,6 @@ spec:
           {{- else }}
           image: "{{.Values.manager.image.repository}}:{{.Values.manager.image.tag}}"
           {{- end }}
-          image: 
           imagePullPolicy: IfNotPresent
           {{- if .Values.manager.securityContext }}
           securityContext:

--- a/sapbtp-operator-charts/templates/deployment.yml
+++ b/sapbtp-operator-charts/templates/deployment.yml
@@ -31,7 +31,13 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+          #image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+          {{- if .Values.manager.rbac.image.sha }}
+          image: "{{.Values.manager.rbac.image.repository}}@sha256:{{.Values.manager.rbac.image.sha}}"
+          {{- else }}
+          image: "{{.Values.manager.rbac.repository}}:{{.Values.manager.rbac.image.tag}}"
+          {{- end }}
+ 
           {{- if .Values.manager.securityContext }}
           securityContext:
           {{ toYaml .Values.manager.securityContext | indent 2 }}
@@ -50,7 +56,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: sap-btp-operator-config
-          image: {{.Values.manager.image.repository}}:{{.Values.manager.image.tag}}
+          {{- if .Values.manager.image.sha}}
+          image: "{{.Values.manager.image.repository}}@sha256:{{.Values.manager.image.sha}}"
+          {{- else }}
+          image: "{{.Values.manager.image.repository}}:{{.Values.manager.image.tag}}"
+          {{- end }}
+          image: 
           imagePullPolicy: IfNotPresent
           {{- if .Values.manager.securityContext }}
           securityContext:

--- a/sapbtp-operator-charts/templates/deployment.yml
+++ b/sapbtp-operator-charts/templates/deployment.yml
@@ -35,7 +35,7 @@ spec:
           {{- if .Values.manager.rbacProxy.image.sha }}
           image: "{{.Values.manager.rbacProxy.image.repository}}@sha256:{{.Values.manager.rbacProxy.image.sha}}"
           {{- else }}
-          image: "{{.Values.manager.rbacProxy.repository}}:{{.Values.manager.rbacProxy.image.tag}}"
+          image: "{{.Values.manager.rbacProxy.image.repository}}:{{.Values.manager.rbacProxy.image.tag}}"
           {{- end }}
  
           {{- if .Values.manager.securityContext }}

--- a/sapbtp-operator-charts/values.yaml
+++ b/sapbtp-operator-charts/values.yaml
@@ -26,6 +26,10 @@ manager:
     sm_url: ""
     tokenurl: ""
     tokenurlsuffix: "/oauth/token"
+  rbacProxy:
+    repository: quay.io/brancz/kube-rbac-proxy
+    sha: ""
+    tag: v0.11.0
   certificates:
     # Configure if https://github.com/jetstack/cert-manager is used
     certManager: true

--- a/sapbtp-operator-charts/values.yaml
+++ b/sapbtp-operator-charts/values.yaml
@@ -15,7 +15,7 @@ manager:
   image:
     repository: ghcr.io/sap/sap-btp-service-operator/controller
     tag: master
-    sh: ""
+    sha: ""
   secret:
     b64encoded: false
     enabled: true

--- a/sapbtp-operator-charts/values.yaml
+++ b/sapbtp-operator-charts/values.yaml
@@ -15,6 +15,7 @@ manager:
   image:
     repository: ghcr.io/sap/sap-btp-service-operator/controller
     tag: master
+    sh: ""
   secret:
     b64encoded: false
     enabled: true

--- a/sapbtp-operator-charts/values.yaml
+++ b/sapbtp-operator-charts/values.yaml
@@ -28,9 +28,10 @@ manager:
     tokenurl: ""
     tokenurlsuffix: "/oauth/token"
   rbacProxy:
-    repository: quay.io/brancz/kube-rbac-proxy
-    sha: ""
-    tag: v0.11.0
+    image:
+      repository: quay.io/brancz/kube-rbac-proxy
+      sha: ""
+      tag: v0.11.0
   certificates:
     # Configure if https://github.com/jetstack/cert-manager is used
     certManager: true


### PR DESCRIPTION
# Pull Request Template

PR resolves #170 

## Motivation
*add better integrity to the image version, we should provide a way to add a digest option to the operator images this way we can validate the image version*

## Approach

_How does this change address the problem?_

Add digest option to btp-operator chart, 
By adding a new `sha` field to  the deployment file and concatenate it to the image string address when provided.

## Pull Request status

* [x] Initial implementation
* [ ] Refactoring
* [ ] Unit tests
* [ ] Integration tests

Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.

## Third-party code

If you use third party code with your contribution such as, components, libraries, or snippets make sure to mention that.


## Work in Progress label

For as long as development of your Pull Request is still ongoing you MUST label it with a **wip** label as well as prefix the name of the PR with *[WIP]*.

For example: *[WIP] Service brokers API*
