### PR TITLE
use sm_url instead of url in kubectl plugin

### DIFF
--- a/hack/kubectl-sapbtp
+++ b/hack/kubectl-sapbtp
@@ -2,7 +2,7 @@
 
 marketplace() {
   local secret=$(kubectl get secret sap-btp-service-operator  -n "$1" -o json)
-  local url=$(jq -r .data.url <<< "$secret" | base64 --decode)
+  local url=$(jq -r .data.sm_url <<< "$secret" | base64 --decode)
   local token=$(_token "$secret")
 
   local services=$(curl -f -Ss -L  -H "Authorization: Bearer ${token}" "$url/v1/service_offerings")
@@ -29,7 +29,7 @@ marketplace() {
 
 plans() {
   local secret=$(kubectl get secret sap-btp-service-operator  -n "$1" -o json)
-  local url=$(jq -r .data.url <<< "$secret" | base64 --decode)
+  local url=$(jq -r .data.sm_url <<< "$secret" | base64 --decode)
   local token=$(_token "$secret")
   local plans=$(curl -f -Ss -L  -H "Authorization: Bearer ${token}" "$url/v1/service_plans")
 
@@ -41,7 +41,7 @@ plans() {
 
 services() {
   local secret=$(kubectl get secret sap-btp-service-operator  -n "$1" -o json)
-  local url=$(jq -r .data.url <<< "$secret" | base64 --decode)
+  local url=$(jq -r .data.sm_url <<< "$secret" | base64 --decode)
   local token=$(_token "$secret")
   local services=$(curl -f -Ss -L  -H "Authorization: Bearer ${token}" "$url/v1/service_offerings")
 


### PR DESCRIPTION
# Pull Request Template

## Prerequisites

I don't have the permissions to assign myself to an issue, therefore creating one is pointless.

## Motivation

Calling `kubectl sapbtp <plans|marketplace|services>` fails on Kyma clusters with `curl: (3) Failed to convert e to ACE; could not convert string to UTF-8`, this is because the `sap-btp-service-operator` secret does not contain the `url` property.

## Approach

Use the `sm_url` property instead

## Pull Request status

* [ ] Initial implementation
* [ ] Refactoring
* [ ] Unit tests
* [ ] Integration tests
* [x] Bug fix

Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.

## Third-party code

If you use third party code with your contribution such as, components, libraries, or snippets make sure to mention that.

