### PR TITLE
Chart labels, annotations, and priorityClass config

### DIFF
--- a/sapbtp-operator-charts/templates/deployment.yml
+++ b/sapbtp-operator-charts/templates/deployment.yml
@@ -12,6 +12,8 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/instance: sap-btp-operator
+      app.kubernetes.io/name: sap-btp-operator
   template:
     metadata:
       annotations:
@@ -20,6 +22,9 @@ spec:
         {{- $secretTls := (include (print $.Template.BasePath "/secret-tls.yml") .) -}}
         {{- $configSha := (print $configmap $secret $secretTls) | sha256sum }}
         checksum/config: {{ $configSha }}
+        {{- if .Values.manager.annotations }}
+        {{- toYaml .Values.manager.annotations | nindent 8 }}
+        {{- end }}
       labels:
         control-plane: controller-manager
         app.kubernetes.io/instance: sap-btp-operator
@@ -112,6 +117,9 @@ spec:
       imagePullSecrets: {{ toYaml .Values.manager.imagePullSecrets | nindent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: 10
+      {{- if .Values.manager.priorityClassName }}
+      priorityClassName: {{ .Values.manager.priorityClassName }}
+      {{- end }}
       volumes:
         - name: cert
           secret:


### PR DESCRIPTION
Kyma project currently uses fork of BTP Operator helm chart with few custom changes. We would like to upstream all configuration knobs and eventually deprecate the https://github.com/kyma-incubator/sap-btp-service-operator.

This is a first PR containing mainly just configurability for deployment annotations and priority class.
