### PR TITLE
[FIX] Credentials: instance_name in metadata corrected

### DIFF
--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -699,7 +699,11 @@ func (r *ServiceBindingReconciler) addInstanceInfo(ctx context.Context, binding 
 		return nil, err
 	}
 
-	credentialsMap["instance_name"] = []byte(binding.Spec.ServiceInstanceName)
+	if instance.Spec.ExternalName != "" {
+		credentialsMap["instance_name"] = []byte(instance.Spec.ExternalName)
+	} else {
+		credentialsMap["instance_name"] = []byte(binding.Spec.ServiceInstanceName)
+	}
 	credentialsMap["instance_guid"] = []byte(instance.Status.InstanceID)
 	credentialsMap["plan"] = []byte(instance.Spec.ServicePlanName)
 	credentialsMap["label"] = []byte(instance.Spec.ServiceOfferingName)


### PR DESCRIPTION
Use externalName from instance, if it exists as the instance_name in service credentials.

Resolves: https://github.com/SAP/sap-btp-service-operator/issues/270

## Motivation

Solves the issue with incorrect instance_name in credentials created by this operator.

## Pull Request status

* [x] Initial implementation
* [ ] Refactoring
* [ ] Unit tests
* [ ] Integration tests
