### PR TITLE
Allow option to manually install CRDs.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -24,7 +24,7 @@ jobs:
           repository: sap/sap-btp-service-operator/controller
           username: ${{ secrets.OPERATOR_USER }}
           password: ${{ secrets.OPERATOR_PAT }}
-          
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
@@ -55,6 +55,7 @@ jobs:
           helm repo index ./out --merge index.yaml
           sed -i "s|${CHART_TGZ_NAME}|${CHART_URL}|g" ./out/index.yaml | sh
           mv ./hack/kubectl-sapbtp ./out/kubectl-sapbtp
+          make HELM_WRAPPED_CRDS=false HELM_EXPORT_CRD_PATH='./out/crd.yml' helm-charts
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2

--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,8 @@ lint-deps:
 
 helm-charts:
 	@{\
-  	  set -e ;\
-      printf '$(HELM_WRAP_PREFIX)';\
-      kustomize build './config/default';\
-      printf '$(HELM_WRAP_SUFFIX)';\
-    } > '$(HELM_EXPORT_CRD_PATH)';
+	  set -e ;\
+	  printf '$(HELM_WRAP_PREFIX)';\
+	  kustomize build './config/default';\
+	  printf '$(HELM_WRAP_SUFFIX)';\
+	} > '$(HELM_EXPORT_CRD_PATH)';

--- a/README.md
+++ b/README.md
@@ -127,7 +127,27 @@ It is implemented using a [CRDs-based](https://kubernetes.io/docs/concepts/exten
         --set manager.secret.tokenurl=<certurl>
     ```
 **Note:**<br> In order to rotate the credentials between the BTP service operator and Service Manager, you have to create a new binding for the service-operator-access service instance, and then to execute the setup script again, with the new set of credentials. Afterwards you can delete the old binding.
-        
+
+## Helm Managed CRDs vs manualy installed
+
+By default, the operator will install it's CRDs during a helm install. This behaviour can be changed by overriding chart values.
+
+```bash
+helm upgrade --install <release-name> sap-btp-operator/sap-btp-operator \
+  --create-namespace \
+  --namespace=sap-btp-operator \
+  --set manager.secret.clientid=<clientid> \
+  --set manager.secret.tls.crt="$(cat /path/to/cert)" \
+  --set manager.secret.tls.key="$(cat /path/to/key)" \
+  --set manager.secret.sm_url=<sm_url> \
+  --set manager.secret.tokenurl=<certurl> \
+  --set installCRDs=false
+```
+
+If you opt in for this behaviour then you can apply the crd, at your discretion.
+```
+kubectl apply -f https://github.com/SAP/sap-btp-service-operator/releases/download/v<TAG>/crd.yml
+```
 
 [Back to top](#sap-business-technology-platform-sap-btp-service-operator-for-kubernetes).
 

--- a/sapbtp-operator-charts/templates/crd.yml
+++ b/sapbtp-operator-charts/templates/crd.yml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -129,6 +130,10 @@ spec:
                   be in the namespace of the binding
                 minLength: 1
                 type: string
+              serviceInstanceNamespace:
+                description: The namespace of the referenced instance, if empty Binding's
+                  namespace will be used
+                type: string
               userInfo:
                 description: UserInfo contains information about the user that last
                   modified this instance. This field is set by the API server and
@@ -174,8 +179,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
@@ -426,8 +431,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
@@ -542,6 +547,9 @@ spec:
     - jsonPath: .spec.servicePlanName
       name: Plan
       type: string
+    - jsonPath: .spec.shared
+      name: shared
+      type: boolean
     - jsonPath: .spec.dataCenter
       name: dataCenter
       type: string
@@ -643,7 +651,7 @@ spec:
                 minLength: 1
                 type: string
               shared:
-                description: Indicates if the instance aim to be shared, default is false
+                description: Indicates the desired shared state
                 type: boolean
               userInfo:
                 description: UserInfo contains information about the user that last
@@ -687,8 +695,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
@@ -750,6 +758,9 @@ spec:
                   - type
                   type: object
                 type: array
+              hashedSpec:
+                description: HashedSpec is the hashed spec without the shared property
+                type: string
               instanceID:
                 description: The generated ID of the instance, will be automatically
                   filled once the instance is created
@@ -767,9 +778,6 @@ spec:
                 type: string
               ready:
                 description: Indicates whether instance is ready for usage
-                type: string
-              hashedSpec:
-                description: hashed spec
                 type: string
               tags:
                 description: Tags describing the ServiceInstance as provided in service
@@ -798,9 +806,6 @@ spec:
       type: string
     - jsonPath: .status.ready
       name: Ready
-      type: string
-    - jsonPath: .status.shared
-      name: Shared
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -890,7 +895,7 @@ spec:
                 minLength: 1
                 type: string
               shared:
-                description: Indicates if the instance aim to be shared, default is false
+                description: Indicates the desired shared state
                 type: boolean
               userInfo:
                 description: UserInfo contains information about the user that last
@@ -934,8 +939,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
@@ -1015,9 +1020,6 @@ spec:
               ready:
                 description: Indicates whether instance is ready for usage
                 type: string
-              hashedSpec:
-                description: hashed spec
-                type: string
               tags:
                 description: Tags describing the ServiceInstance as provided in service
                   catalog, will be copied to `ServiceBinding` secret in the key called
@@ -1033,3 +1035,4 @@ spec:
     storage: false
     subresources:
       status: {}
+{{- end }}

--- a/sapbtp-operator-charts/values.yaml
+++ b/sapbtp-operator-charts/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# If chart should manage the CRDs or you will install them separately
+installCRDs: true
+
 manager:
   memory_limit: 200Mi
   cpu_limit: 250m


### PR DESCRIPTION
# Pull Request Template

## Prerequisites

Issue: #337 

## Motivation

Allow CRDs to be installed separately so that helm / kubernetes validations can be applied without installation. 

## Approach

The PR leaves the default behaviour in place, only those that opt in will not get the CRDs installed.
During release a new artifact will be bundled `crd.yml` for download by clients.

## Pull Request status

* [x] Initial implementation

## Third-party code
N/A
