### PR TITLE
bug fix - avoid instance update if spec not changed

### DIFF
--- a/api/v1/serviceinstance_validating_webhook.go
+++ b/api/v1/serviceinstance_validating_webhook.go
@@ -49,8 +49,12 @@ func SetAllowMultipleTenants(isAllowed bool) {
 
 func (si *ServiceInstance) ValidateCreate() (warnings admission.Warnings, err error) {
 	serviceinstancelog.Info("validate create", "name", si.Name)
+	//TODO remove
+	if len(si.Spec.SubaccountID) > 0 {
+		return nil, fmt.Errorf("setting the subaccountID property is yet supported")
+	}
 	if !allowMultipleTenants && len(si.Spec.SubaccountID) > 0 {
-		serviceinstancelog.Error(fmt.Errorf("invalid subaccountID property"), "the operator installation does not allow multiple subaccunts")
+		serviceinstancelog.Error(fmt.Errorf("invalid subaccountID property"), "the operator installation does not allow multiple subaccounts")
 		return nil, fmt.Errorf("setting the subaccountID property is not allowed")
 	}
 	return nil, nil
@@ -58,6 +62,10 @@ func (si *ServiceInstance) ValidateCreate() (warnings admission.Warnings, err er
 
 func (si *ServiceInstance) ValidateUpdate(old runtime.Object) (warnings admission.Warnings, err error) {
 	serviceinstancelog.Info("validate update", "name", si.Name)
+	//TODO remove
+	if len(si.Spec.SubaccountID) > 0 {
+		return nil, fmt.Errorf("setting the subaccountID property is yet supported")
+	}
 	oldInstance := old.(*ServiceInstance)
 	if oldInstance.Spec.SubaccountID != si.Spec.SubaccountID {
 		return nil, fmt.Errorf("changing the subaccountID for an existing instance is not allowed")

--- a/api/v1/serviceinstance_validating_webhook.go
+++ b/api/v1/serviceinstance_validating_webhook.go
@@ -49,10 +49,6 @@ func SetAllowMultipleTenants(isAllowed bool) {
 
 func (si *ServiceInstance) ValidateCreate() (warnings admission.Warnings, err error) {
 	serviceinstancelog.Info("validate create", "name", si.Name)
-	//TODO remove
-	if len(si.Spec.SubaccountID) > 0 {
-		return nil, fmt.Errorf("setting the subaccountID property is yet supported")
-	}
 	if !allowMultipleTenants && len(si.Spec.SubaccountID) > 0 {
 		serviceinstancelog.Error(fmt.Errorf("invalid subaccountID property"), "the operator installation does not allow multiple subaccounts")
 		return nil, fmt.Errorf("setting the subaccountID property is not allowed")
@@ -62,10 +58,7 @@ func (si *ServiceInstance) ValidateCreate() (warnings admission.Warnings, err er
 
 func (si *ServiceInstance) ValidateUpdate(old runtime.Object) (warnings admission.Warnings, err error) {
 	serviceinstancelog.Info("validate update", "name", si.Name)
-	//TODO remove
-	if len(si.Spec.SubaccountID) > 0 {
-		return nil, fmt.Errorf("setting the subaccountID property is yet supported")
-	}
+
 	oldInstance := old.(*ServiceInstance)
 	if oldInstance.Spec.SubaccountID != si.Spec.SubaccountID {
 		return nil, fmt.Errorf("changing the subaccountID for an existing instance is not allowed")

--- a/api/v1/serviceinstance_validating_webhook_test.go
+++ b/api/v1/serviceinstance_validating_webhook_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Service Instance Webhook Test", func() {
 		instance = getInstance()
 	})
 
-	Context("Validate Create", func() {
+	XContext("Validate Create", func() {
 		When("multiple subaccounts is not allowed and subaccountID exists", func() {
 			It("should fail", func() {
 				instance := getInstanceWithSubaccountID()
@@ -24,7 +24,7 @@ var _ = Describe("Service Instance Webhook Test", func() {
 		})
 	})
 
-	Context("Validate Update", func() {
+	XContext("Validate Update", func() {
 		When("multiple subaccounts is not allowed and subaccountID changed", func() {
 			It("should fail", func() {
 				instance := getInstanceWithSubaccountID()

--- a/api/v1/serviceinstance_validating_webhook_test.go
+++ b/api/v1/serviceinstance_validating_webhook_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Service Instance Webhook Test", func() {
 		instance = getInstance()
 	})
 
-	XContext("Validate Create", func() {
+	Context("Validate Create", func() {
 		When("multiple subaccounts is not allowed and subaccountID exists", func() {
 			It("should fail", func() {
 				instance := getInstanceWithSubaccountID()
@@ -24,7 +24,7 @@ var _ = Describe("Service Instance Webhook Test", func() {
 		})
 	})
 
-	XContext("Validate Update", func() {
+	Context("Validate Update", func() {
 		When("multiple subaccounts is not allowed and subaccountID changed", func() {
 			It("should fail", func() {
 				instance := getInstanceWithSubaccountID()

--- a/config/samples/services_v1_serviceinstance.yaml
+++ b/config/samples/services_v1_serviceinstance.yaml
@@ -4,4 +4,4 @@ metadata:
   name: sample-instance-1
 spec:
   serviceOfferingName: service-manager
-  servicePlanName: subaccount-admin
+  servicePlanName: subaccount-audit

--- a/controllers/base_controller.go
+++ b/controllers/base_controller.go
@@ -202,7 +202,7 @@ func setInProgressConditions(ctx context.Context, operationType smClientTypes.Op
 		Status:             metav1.ConditionFalse,
 		Reason:             getConditionReason(operationType, smClientTypes.INPROGRESS),
 		Message:            message,
-		ObservedGeneration: object.GetGeneration(),
+		ObservedGeneration: object.GetObservedGeneration(),
 	}
 	meta.SetStatusCondition(&conditions, lastOpCondition)
 	meta.SetStatusCondition(&conditions, getReadyCondition(object))
@@ -230,14 +230,14 @@ func setSuccessConditions(operationType smClientTypes.OperationCategory, object 
 		Status:             metav1.ConditionTrue,
 		Reason:             getConditionReason(operationType, smClientTypes.SUCCEEDED),
 		Message:            message,
-		ObservedGeneration: object.GetGeneration(),
+		ObservedGeneration: object.GetObservedGeneration(),
 	}
 	readyCondition := metav1.Condition{
 		Type:               api.ConditionReady,
 		Status:             metav1.ConditionTrue,
 		Reason:             Provisioned,
 		Message:            message,
-		ObservedGeneration: object.GetGeneration(),
+		ObservedGeneration: object.GetObservedGeneration(),
 	}
 	meta.SetStatusCondition(&conditions, lastOpCondition)
 	meta.SetStatusCondition(&conditions, readyCondition)
@@ -257,7 +257,7 @@ func setCredRotationInProgressConditions(reason, message string, object api.SAPB
 		Status:             metav1.ConditionTrue,
 		Reason:             reason,
 		Message:            message,
-		ObservedGeneration: object.GetGeneration(),
+		ObservedGeneration: object.GetObservedGeneration(),
 	}
 	meta.SetStatusCondition(&conditions, credRotCondition)
 	object.SetConditions(conditions)
@@ -286,7 +286,7 @@ func setFailureConditions(operationType smClientTypes.OperationCategory, errorMe
 		Status:             metav1.ConditionFalse,
 		Reason:             reason,
 		Message:            message,
-		ObservedGeneration: object.GetGeneration(),
+		ObservedGeneration: object.GetObservedGeneration(),
 	}
 	meta.SetStatusCondition(&conditions, lastOpCondition)
 
@@ -295,7 +295,7 @@ func setFailureConditions(operationType smClientTypes.OperationCategory, errorMe
 		Status:             metav1.ConditionTrue,
 		Reason:             reason,
 		Message:            message,
-		ObservedGeneration: object.GetGeneration(),
+		ObservedGeneration: object.GetObservedGeneration(),
 	}
 	meta.SetStatusCondition(&conditions, failedCondition)
 	meta.SetStatusCondition(&conditions, getReadyCondition(object))
@@ -400,5 +400,5 @@ func getReadyCondition(object api.SAPBTPResource) metav1.Condition {
 		reason = Provisioned
 	}
 
-	return metav1.Condition{Type: api.ConditionReady, Status: status, Reason: reason, ObservedGeneration: object.GetGeneration()}
+	return metav1.Condition{Type: api.ConditionReady, Status: status, Reason: reason}
 }

--- a/controllers/base_controller.go
+++ b/controllers/base_controller.go
@@ -310,7 +310,7 @@ func setBlockedCondition(ctx context.Context, message string, object api.SAPBTPR
 	lastOpCondition.Reason = Blocked
 }
 
-func isDelete(object metav1.ObjectMeta) bool {
+func isMarkedForDeletion(object metav1.ObjectMeta) bool {
 	return !object.DeletionTimestamp.IsZero()
 }
 

--- a/controllers/serviceinstance_controller.go
+++ b/controllers/serviceinstance_controller.go
@@ -538,6 +538,9 @@ func isFinalState(ctx context.Context, serviceInstance *servicesv1.ServiceInstan
 
 	if sharingUpdateRequired(serviceInstance) {
 		log.Info("instance is not in final state, need to sync sharing status")
+		if len(serviceInstance.Status.HashedSpec) == 0 {
+			updateHashedSpecValue(serviceInstance)
+		}
 		return false
 	}
 

--- a/controllers/serviceinstance_controller.go
+++ b/controllers/serviceinstance_controller.go
@@ -78,6 +78,8 @@ func (r *ServiceInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	if isDelete(serviceInstance.ObjectMeta) {
+		// delete updates the generation
+		serviceInstance.SetObservedGeneration(serviceInstance.Generation)
 		return r.deleteInstance(ctx, serviceInstance)
 	}
 

--- a/controllers/serviceinstance_controller_test.go
+++ b/controllers/serviceinstance_controller_test.go
@@ -34,7 +34,6 @@ const (
 	testNamespace            = "ic-test-namespace"
 	fakeOfferingName         = "offering-a"
 	fakePlanName             = "plan-a"
-	testSubaccountID         = "subaccountID"
 )
 
 var _ = Describe("ServiceInstance controller", func() {
@@ -206,7 +205,7 @@ var _ = Describe("ServiceInstance controller", func() {
 				})
 			})
 
-			When("multiple subaccounts is disabled", func() {
+			XWhen("multiple subaccounts is disabled", func() {
 				BeforeEach(func() {
 					v1.SetAllowMultipleTenants(false)
 				})
@@ -369,6 +368,7 @@ var _ = Describe("ServiceInstance controller", func() {
 			})
 
 			When("deleting while create is in progress", func() {
+				//KEREN
 				It("should be deleted successfully", func() {
 					serviceInstance = createInstance(ctx, instanceSpec, false)
 
@@ -581,7 +581,7 @@ var _ = Describe("ServiceInstance controller", func() {
 			})
 		})
 
-		When("subaccount id changed", func() {
+		XWhen("subaccount id changed", func() {
 			It("should fail", func() {
 				deleteInstance(ctx, serviceInstance, true)
 				serviceInstance = createInstance(ctx, instanceSpec, true)
@@ -669,7 +669,7 @@ var _ = Describe("ServiceInstance controller", func() {
 				deleteInstance(ctx, serviceInstance, false)
 				waitForResourceCondition(ctx, serviceInstance, api.ConditionSucceeded, metav1.ConditionFalse, DeleteInProgress, "")
 			})
-
+			//KEREN
 			When("polling ends with success", func() {
 				BeforeEach(func() {
 					fakeClient.StatusReturns(&smclientTypes.Operation{

--- a/controllers/serviceinstance_controller_test.go
+++ b/controllers/serviceinstance_controller_test.go
@@ -205,7 +205,7 @@ var _ = Describe("ServiceInstance controller", func() {
 				})
 			})
 
-			XWhen("multiple subaccounts is disabled", func() {
+			When("multiple subaccounts is disabled", func() {
 				BeforeEach(func() {
 					v1.SetAllowMultipleTenants(false)
 				})
@@ -368,7 +368,6 @@ var _ = Describe("ServiceInstance controller", func() {
 			})
 
 			When("deleting while create is in progress", func() {
-				//KEREN
 				It("should be deleted successfully", func() {
 					serviceInstance = createInstance(ctx, instanceSpec, false)
 
@@ -581,7 +580,7 @@ var _ = Describe("ServiceInstance controller", func() {
 			})
 		})
 
-		XWhen("subaccount id changed", func() {
+		When("subaccount id changed", func() {
 			It("should fail", func() {
 				deleteInstance(ctx, serviceInstance, true)
 				serviceInstance = createInstance(ctx, instanceSpec, true)
@@ -669,7 +668,6 @@ var _ = Describe("ServiceInstance controller", func() {
 				deleteInstance(ctx, serviceInstance, false)
 				waitForResourceCondition(ctx, serviceInstance, api.ConditionSucceeded, metav1.ConditionFalse, DeleteInProgress, "")
 			})
-			//KEREN
 			When("polling ends with success", func() {
 				BeforeEach(func() {
 					fakeClient.StatusReturns(&smclientTypes.Operation{

--- a/controllers/serviceinstance_controller_test.go
+++ b/controllers/serviceinstance_controller_test.go
@@ -1042,7 +1042,7 @@ var _ = Describe("ServiceInstance controller", func() {
 							ExternalName: "name",
 						}}
 					instance.SetGeneration(2)
-					Expect(isFinalState(instance)).To(BeFalse())
+					Expect(isFinalState(ctx, instance)).To(BeFalse())
 				})
 
 				When("Succeeded is false", func() {
@@ -1068,8 +1068,31 @@ var _ = Describe("ServiceInstance controller", func() {
 							},
 						}
 						instance.SetGeneration(1)
-						Expect(isFinalState(instance)).To(BeFalse())
+						Expect(isFinalState(ctx, instance)).To(BeFalse())
 					})
+				})
+			})
+
+			When("async operation in progress", func() {
+				It("should return false", func() {
+					var instance = &v1.ServiceInstance{
+						Status: v1.ServiceInstanceStatus{
+							Conditions: []metav1.Condition{
+								{
+									Type:               api.ConditionReady,
+									Status:             metav1.ConditionTrue,
+									ObservedGeneration: 1,
+								},
+							},
+							HashedSpec:         "929e78f4449f8036ce39da3cc3e7eaea",
+							OperationURL:       "/operations/somepollingurl",
+							ObservedGeneration: 2,
+						},
+						Spec: v1.ServiceInstanceSpec{
+							ExternalName: "name",
+						}}
+					instance.SetGeneration(2)
+					Expect(isFinalState(ctx, instance)).To(BeFalse())
 				})
 			})
 
@@ -1095,7 +1118,7 @@ var _ = Describe("ServiceInstance controller", func() {
 							ExternalName: "name",
 						}}
 					instance.SetGeneration(2)
-					Expect(isFinalState(instance)).To(BeFalse())
+					Expect(isFinalState(ctx, instance)).To(BeFalse())
 				})
 			})
 
@@ -1121,7 +1144,7 @@ var _ = Describe("ServiceInstance controller", func() {
 							ExternalName: "name",
 						}}
 					instance.SetGeneration(2)
-					Expect(isFinalState(instance)).To(BeFalse())
+					Expect(isFinalState(ctx, instance)).To(BeFalse())
 				})
 			})
 
@@ -1153,7 +1176,7 @@ var _ = Describe("ServiceInstance controller", func() {
 							Shared:       pointer.Bool(true),
 						}}
 					instance.SetGeneration(2)
-					Expect(isFinalState(instance)).To(BeFalse())
+					Expect(isFinalState(ctx, instance)).To(BeFalse())
 				})
 			})
 
@@ -1177,14 +1200,15 @@ var _ = Describe("ServiceInstance controller", func() {
 									Status: metav1.ConditionTrue,
 								},
 							},
-							HashedSpec: "929e78f4449f8036ce39da3cc3e7eaea",
+							HashedSpec:         "929e78f4449f8036ce39da3cc3e7eaea",
+							ObservedGeneration: 2,
 						},
 						Spec: v1.ServiceInstanceSpec{
 							ExternalName: "name",
 							Shared:       pointer.Bool(true),
 						}}
 					instance.SetGeneration(2)
-					Expect(isFinalState(instance)).To(BeTrue())
+					Expect(isFinalState(ctx, instance)).To(BeTrue())
 				})
 			})
 		})


### PR DESCRIPTION
when upgrading the operator from old releases the operator will send an update request to the broker for instances without status.hashedSpec value even if the instance was not changed, this might lead to an error since there are brokers who does not support updates
