### PR TITLE
block cluster id change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22.1-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.22.2-alpine as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/common/utils/secret_template.go
+++ b/api/common/utils/secret_template.go
@@ -164,7 +164,7 @@ var allowedSprigFunctions = map[string]interface{}{
 	// "typeIsLike": nil,
 	// "kindOf":     nil,
 	// "kindIs":     nil,
-	"deepEqual":  nil,
+	"deepEqual": nil,
 
 	// OS:
 	// "env":       nil,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	AllowedNamespaces      []string      `envconfig:"allowed_namespaces"`
 	EnableNamespaceSecrets bool          `envconfig:"enable_namespace_secrets"`
 	ClusterID              string        `envconfig:"cluster_id"`
+	InitialClusterID       string        `envconfig:"initial_cluster_id"`
 	RetryBaseDelay         time.Duration
 	RetryMaxDelay          time.Duration
 }

--- a/main.go
+++ b/main.go
@@ -17,12 +17,17 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
-	"github.com/SAP/sap-btp-service-operator/internal/utils"
-
+	"github.com/SAP/sap-btp-service-operator/api/v1/webhooks"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/SAP/sap-btp-service-operator/internal/utils"
 
 	"k8s.io/client-go/rest"
 
@@ -30,9 +35,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-
-	"github.com/SAP/sap-btp-service-operator/api/v1/webhooks"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -102,6 +104,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if len(config.Get().InitialClusterID) == 0 {
+		setupLog.Info("cluster secret not found, creating it")
+		createClusterSecret(mgr.GetClient())
+	} else if config.Get().InitialClusterID != config.Get().ClusterID {
+		panic(fmt.Sprintf("clusterID changed, not supported! deploy with --set cluster.id=%s", config.Get().InitialClusterID))
+	}
+
 	secretResolver := &utils.SecretResolver{
 		ManagementNamespace:    config.Get().ManagementNamespace,
 		ReleaseNamespace:       config.Get().ReleaseNamespace,
@@ -161,5 +170,16 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
+	}
+
+}
+
+func createClusterSecret(client client.Client) {
+	clusterSecret := &v1.Secret{}
+	clusterSecret.Name = "sap-btp-operator-clusterid"
+	clusterSecret.Namespace = config.Get().ReleaseNamespace
+	clusterSecret.StringData = map[string]string{"INITIAL_CLUSTER_ID": config.Get().ClusterID}
+	if err := client.Create(context.Background(), clusterSecret); err != nil {
+		setupLog.Error(err, "failed to create cluster secret")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 		setupLog.Info("cluster secret not found, creating it")
 		createClusterSecret(mgr.GetClient())
 	} else if config.Get().InitialClusterID != config.Get().ClusterID {
-		panic(fmt.Sprintf("clusterID changed, not supported! deploy with --set cluster.id=%s", config.Get().InitialClusterID))
+		panic(fmt.Sprintf("ClusterID changed, which is not supported. Please redeploy with --set cluster.id=%s", config.Get().InitialClusterID))
 	}
 
 	secretResolver := &utils.SecretResolver{

--- a/sapbtp-operator-charts/templates/deployment.yml
+++ b/sapbtp-operator-charts/templates/deployment.yml
@@ -80,6 +80,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: sap-btp-operator-config
+            - secretRef:
+                name: sap-btp-operator-clusterid
           {{- if and ( .Values.manager.image.sha ) ( .Values.manager.image.tag ) }}
           image: "{{.Values.manager.image.repository}}:{{.Values.manager.image.tag}}@sha256:{{.Values.manager.image.sha}}"
           {{- else if .Values.manager.image.sha}}

--- a/sapbtp-operator-charts/templates/deployment.yml
+++ b/sapbtp-operator-charts/templates/deployment.yml
@@ -82,6 +82,7 @@ spec:
                 name: sap-btp-operator-config
             - secretRef:
                 name: sap-btp-operator-clusterid
+                optional: true
           {{- if and ( .Values.manager.image.sha ) ( .Values.manager.image.tag ) }}
           image: "{{.Values.manager.image.repository}}:{{.Values.manager.image.tag}}@sha256:{{.Values.manager.image.sha}}"
           {{- else if .Values.manager.image.sha}}


### PR DESCRIPTION
## Motivation

changing the cluster id of an existing cluster can cause unexpected behavior and malfunctioning of the operator.
Therefore in the case cluster id is changed the operator will fail to start until reverted to initial cluster id

