### PR TITLE
OOM due to secrets/configmaps - limited cache implementation

### DIFF
--- a/api/common/consts.go
+++ b/api/common/consts.go
@@ -1,6 +1,8 @@
 package common
 
 const (
+	ManagedByBTPOperatorLabel = "services.cloud.sap.com/managed-by-sap-btp-operator"
+
 	NamespaceLabel = "_namespace"
 	K8sNameLabel   = "_k8sname"
 	ClusterIDLabel = "_clusterid"

--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -605,6 +605,11 @@ func (r *ServiceBindingReconciler) storeBindingSecret(ctx context.Context, k8sBi
 		return err
 	}
 
+	if len(secret.Labels) == 0 {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels[common.ManagedByBTPOperatorLabel] = "true"
+
 	return r.createOrUpdateBindingSecret(ctx, k8sBinding, secret)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	AllowClusterAccess     bool          `envconfig:"allow_cluster_access"`
 	AllowedNamespaces      []string      `envconfig:"allowed_namespaces"`
 	EnableNamespaceSecrets bool          `envconfig:"enable_namespace_secrets"`
+	EnableLimitedCache     bool          `envconfig:"enable_limited_cache"`
 	ClusterID              string        `envconfig:"cluster_id"`
 	InitialClusterID       string        `envconfig:"initial_cluster_id"`
 	RetryBaseDelay         time.Duration
@@ -34,6 +35,7 @@ func Get() Config {
 			PollInterval:           10 * time.Second,
 			LongPollInterval:       5 * time.Minute,
 			EnableNamespaceSecrets: true,
+			EnableLimitedCache:     false,
 			AllowedNamespaces:      []string{},
 			AllowClusterAccess:     true,
 			RetryBaseDelay:         10 * time.Second,

--- a/sapbtp-operator-charts/templates/configmap.yml
+++ b/sapbtp-operator-charts/templates/configmap.yml
@@ -1,4 +1,10 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sap-btp-operator-config
+  namespace: {{.Release.Namespace}}
+  labels:
+    "services.cloud.sap.com/managed-by-sap-btp-operator": "true"
 data:
   {{- if .Values.cluster.id }}
   CLUSTER_ID: {{ .Values.cluster.id }}
@@ -16,13 +22,10 @@ data:
   MANAGEMENT_NAMESPACE: {{.Release.Namespace}}
   {{- end }}
   RELEASE_NAMESPACE: {{.Release.Namespace}}
+  ENABLE_LIMITED_CACHE: {{ .Values.manager.enable_limited_cache | quote }}
   ALLOW_CLUSTER_ACCESS: {{ .Values.manager.allow_cluster_access | quote }}
   {{- if not .Values.manager.allow_cluster_access }}
   {{- if gt (len .Values.manager.allowed_namespaces) 0 }}
   ALLOWED_NAMESPACES: {{ join "," .Values.manager.allowed_namespaces }}
   {{- end }}
   {{- end }}
-kind: ConfigMap
-metadata:
-  name: sap-btp-operator-config
-  namespace: {{.Release.Namespace}}

--- a/sapbtp-operator-charts/templates/secret.yml
+++ b/sapbtp-operator-charts/templates/secret.yml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: sap-btp-service-operator
   namespace: {{ .Release.Namespace }}
+  labels:
+    "services.cloud.sap.com/managed-by-sap-btp-operator": "true"
 type: Opaque
 data:
   {{- if .Values.manager.secret.b64encoded }}

--- a/sapbtp-operator-charts/values.yaml
+++ b/sapbtp-operator-charts/values.yaml
@@ -8,6 +8,7 @@ manager:
   req_memory_limit: 20Mi
   req_cpu_limit: 100m
   allow_cluster_access: true
+  enable_limited_cache: false
   allowed_namespaces: []
   replica_count: 2
   enable_leader_election: true


### PR DESCRIPTION
This feature is disabled by default, it should be enabled when btp opeartor is crashing due to OOM during startup that is caused in cluster that has many secrets/configmaps.

it is the user's responsibility to label the relevant secrets/configmaps with the needed label:
"services.cloud.sap.com/managed-by-sap-btp-operator": "true