### PR TITLE
[WIP] Add option for adding annotations

### DIFF
--- a/sapbtp-operator-charts/templates/configmap.yml
+++ b/sapbtp-operator-charts/templates/configmap.yml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{.Release.Namespace}}
   labels:
     "services.cloud.sap.com/managed-by-sap-btp-operator": "true"
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   {{- if .Values.cluster.id }}
   CLUSTER_ID: {{ .Values.cluster.id }}

--- a/sapbtp-operator-charts/templates/secret.yml
+++ b/sapbtp-operator-charts/templates/secret.yml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     "services.cloud.sap.com/managed-by-sap-btp-operator": "true"
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- if .Values.manager.secret.b64encoded }}

--- a/sapbtp-operator-charts/values.yaml
+++ b/sapbtp-operator-charts/values.yaml
@@ -87,6 +87,8 @@ manager:
     enabled: false
   kubernetesMatchLabels:
     enabled: false
+# Option for adding annotations
+# annotations: {}
 cluster:
   id:
 externalImages:


### PR DESCRIPTION
# Pull Request Template

## Prerequisites

https://github.com/SAP/sap-btp-service-operator/issues/481

## Motivation

I am using the btp-operator in a setup where it (among other microservices) is deployed via ArgoCD.
The parameters I use in the [secret](https://github.com/SAP/sap-btp-service-operator/blob/main/sapbtp-operator-charts/templates/secret.yml) are imported from Hashicorp Vault via the ArgoCD Vault Plugin. Its' functionality relies on a [certain annotation](https://argocd-vault-plugin.readthedocs.io/en/stable/howitworks/) of the secret template and the current version of the secret doesn't provide the option to add this annotation.

## Approach

With few simple changes of the secret template and the values file we can add the option for custom annotations.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests

## Third-party code

N/A

