### PR TITLE
Bug fix - create binding when instance update failed should be allowed

### DIFF
--- a/config/crd/bases/services.cloud.sap.com_servicebindings.yaml
+++ b/config/crd/bases/services.cloud.sap.com_servicebindings.yaml
@@ -273,10 +273,6 @@ spec:
                 description: Indicates when binding secret was rotated
                 format: date-time
                 type: string
-              observedGeneration:
-                description: Last generation that was acted on
-                format: int64
-                type: integer
               operationType:
                 description: The operation type (CREATE/UPDATE/DELETE) for ongoing
                   operation

--- a/config/crd/bases/services.cloud.sap.com_serviceinstances.yaml
+++ b/config/crd/bases/services.cloud.sap.com_serviceinstances.yaml
@@ -255,10 +255,6 @@ spec:
                 description: The generated ID of the instance, will be automatically
                   filled once the instance is created
                 type: string
-              observedGeneration:
-                description: Last generation that was acted on
-                format: int64
-                type: integer
               operationType:
                 description: The operation type (CREATE/UPDATE/DELETE) for ongoing
                   operation

--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -171,7 +171,7 @@ func (r *ServiceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return r.maintain(ctx, serviceBinding)
 	}
 
-	if serviceInstanceNotUsable(serviceInstance) {
+	if !serviceInstanceUsable(serviceInstance) {
 		instanceErr := fmt.Errorf("service instance '%s' is not usable", serviceBinding.Spec.ServiceInstanceName)
 		utils.SetBlockedCondition(ctx, instanceErr.Error(), serviceBinding)
 		if err := utils.UpdateStatus(ctx, r.Client, serviceBinding); err != nil {
@@ -1148,11 +1148,11 @@ func bindingAlreadyOwnedByInstance(instance *v1.ServiceInstance, binding *v1.Ser
 	return false
 }
 
-func serviceInstanceNotUsable(instance *v1.ServiceInstance) bool {
+func serviceInstanceUsable(instance *v1.ServiceInstance) bool {
 	if utils.IsMarkedForDeletion(instance.ObjectMeta) {
-		return true
+		return false
 	}
-	return instance.Status.Ready != metav1.ConditionTrue
+	return instance.Status.Ready == metav1.ConditionTrue
 }
 
 func getInstanceNameForSecretCredentials(instance *v1.ServiceInstance) []byte {

--- a/controllers/servicebinding_controller_test.go
+++ b/controllers/servicebinding_controller_test.go
@@ -543,7 +543,7 @@ var _ = Describe("ServiceBinding controller", func() {
 
 				binding, err := createBindingWithoutAssertions(ctx, bindingName, bindingTestNamespace, instanceName, "", "binding-external-name", "", false)
 				Expect(err).ToNot(HaveOccurred())
-				waitForResourceCondition(ctx, binding, common.ConditionSucceeded, metav1.ConditionFalse, "", "is not usable")
+				waitForResourceCondition(ctx, binding, common.ConditionSucceeded, metav1.ConditionFalse, "", "service instance is not ready")
 
 				createdInstance.Status.Ready = metav1.ConditionTrue
 				updateInstanceStatus(ctx, createdInstance)

--- a/controllers/servicebinding_controller_test.go
+++ b/controllers/servicebinding_controller_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"strings"
+
 	"github.com/SAP/sap-btp-service-operator/api/common"
 	"github.com/SAP/sap-btp-service-operator/internal/utils"
 	"github.com/lithammer/dedent"
 	authv1 "k8s.io/api/authentication/v1"
 	"k8s.io/utils/pointer"
-	"net/http"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"strings"
 
 	v1 "github.com/SAP/sap-btp-service-operator/api/v1"
 	"github.com/SAP/sap-btp-service-operator/client/sm"

--- a/controllers/serviceinstance_controller.go
+++ b/controllers/serviceinstance_controller.go
@@ -111,8 +111,7 @@ func (r *ServiceInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return r.poll(ctx, serviceInstance)
 	}
 
-	if !controllerutil.ContainsFinalizer(serviceInstance, common.FinalizerName) {
-		controllerutil.AddFinalizer(serviceInstance, common.FinalizerName)
+	if controllerutil.AddFinalizer(serviceInstance, common.FinalizerName) {
 		log.Info(fmt.Sprintf("added finalizer '%s' to service instance", common.FinalizerName))
 		if err := r.Client.Update(ctx, serviceInstance); err != nil {
 			return ctrl.Result{}, err


### PR DESCRIPTION
https://github.com/SAP/sap-btp-service-operator/issues/490
operator should not block binding creation as long instance is not being deleted or not provisioned