### PR TITLE
resync period

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 			},
 		}
 	}
-	syncPeriod := 10 * time.Second
+	syncPeriod := 10 * time.Hour
 	mgrOptions.Cache.SyncPeriod = &syncPeriod
 
 	if !config.Get().AllowClusterAccess {


### PR DESCRIPTION
set resync period to 10 hours since default was changed to 0 (required for credentails rotation)