### PR TITLE
increase http client timeout

### DIFF
--- a/internal/httputil/http_util.go
+++ b/internal/httputil/http_util.go
@@ -45,7 +45,7 @@ func BuildHTTPClientTLS(tlsCertKey, tlsPrivateKey string) (*http.Client, error) 
 
 func getClient() *http.Client {
 	client := &http.Client{
-		Timeout: time.Second * 30,
+		Timeout: time.Minute * 2,
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{


### PR DESCRIPTION
temp solution for sync provision requests
in the future all requests to service manager should be async
