### PR TITLE
docs: Add note that service-operator-access credentials are not for API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Example binding with X.509 certificate:
     "sm_url": "https://service-manager.cfapps.eu10.hana.ondemand.com"
 }
 ```
+**Note**: The `service-operator-access` credentials are intended exclusively for technical communication between the BTP Service Operator and Service Manager. They are not designed for direct API access. If you need to call Service Manager APIs directly, create a separate Service Manager instance with the `subaccount-admin` plan and use those credentials instead.
 
 - Add the SAP BTP Service Operator Helm chart repository:
 
@@ -168,7 +169,6 @@ stringData:
 
 **Note**: To rotate the credentials between the BTP service operator and Service Manager, you have to create a new binding for the `service-operator-access` service instance, and then execute the setup script again with the new set of credentials. Afterward, you can delete the old binding.
 
-**Note**: The `service-operator-access` credentials are intended exclusively for technical communication between the BTP Service Operator and Service Manager. They are not designed for direct API access. If you need to call Service Manager APIs directly, create a separate Service Manager instance with the `subaccount-admin` plan and use those credentials instead.
 
 [Back to top](#table-of-contents)
 


### PR DESCRIPTION
## Summary

- Add a note in the Installation and Setup section clarifying that `service-operator-access` credentials are intended exclusively for technical communication between the BTP Service Operator and Service Manager
- Direct users to use the `subaccount-admin` plan for direct API access (e.g., Move API, cleanup operations)

## Context

This addresses feedback to improve documentation clarity around credential usage, preventing users from attempting to use `service-operator-access` credentials for Service Manager API calls (which results in 403 Forbidden errors).